### PR TITLE
Updating WebBlocks.js to work with Umbraco 6.2.5. The standard jquery…

### DIFF
--- a/WebBlocks/WebBlocks/Scripts/WebBlocks.js
+++ b/WebBlocks/WebBlocks/Scripts/WebBlocks.js
@@ -441,12 +441,15 @@ $(document).ready(function () {
 });
 
 function ensureLoggedInForProtectedPage(callback) {
-    if (isProtectedPage)
-        $.post("/WebBlocksProtectedPage.ashx", { command: "signin", username: username, password: password }, function () {
-            callback();
-        });
-    else
-        callback();
+	if (isProtectedPage)
+		$.ajax({
+			method: "POST",
+			url: "/WebBlocksProtectedPage.ashx",
+			data: { command: "signin", username: username, password: password },
+			success: callback()
+		});
+	else
+		callback();
 }
 
 function webBlocksLogOut() {


### PR DESCRIPTION
… $.POST doesn't seem to send a useful Content-Type header which stops the membership login controller being able to read the username / password passed by web blocks.
