### PR TITLE
adds try catch around BlockControllerCache.BuildCache so that failing…

### DIFF
--- a/WebBlocks/WebBlocks/Controllers/BlockControllerCache.cs
+++ b/WebBlocks/WebBlocks/Controllers/BlockControllerCache.cs
@@ -19,9 +19,17 @@ namespace WebBlocks.Controllers
         {
             foreach(var asm in AppDomain.CurrentDomain.GetAssemblies())
             {
-                Controllers.AddRange(asm.GetTypes()
-                    .Where(type => typeof(Umbraco.Web.Mvc.SurfaceController).IsAssignableFrom(type))
-                    .Select(x => x.Name.TrimEnd("Controller")));
+                try
+                {
+                    Controllers.AddRange(asm.GetTypes()
+                        .Where(type => typeof(Umbraco.Web.Mvc.SurfaceController).IsAssignableFrom(type))
+                        .Select(x => x.Name.TrimEnd("Controller")));
+                }
+                catch
+                {
+                    Umbraco.Core.Logging.Logger.CreateWithDefaultLog4NetConfiguration().Info(
+                        System.Reflection.MethodBase.GetCurrentMethod().DeclaringType, "BlockControllerCache.BuildCache() : Error adding controllers from assemblies");
+                }
             }
         }
     }


### PR DESCRIPTION
… to register some controllers from assemblies doesn't stop the whole start-up process