### PR TITLE
bug fix when renderign a block

### DIFF
--- a/WebBlocks/WebBlocks.SandboxV7/App_Plugins/WebBlocks/package.manifest
+++ b/WebBlocks/WebBlocks.SandboxV7/App_Plugins/WebBlocks/package.manifest
@@ -72,6 +72,13 @@
 						key: "disableContainerDragging",
 						view: "boolean",
 						validation: []
+					},
+					{
+						label: "Authenticate as member on protected pages",
+						description: "Enter the member username that will give access to protected pages in order to render them in the backoffice",
+						key: "memberUsername",
+						view: "textstring",
+						validation: []
 					}
 				]
 			}

--- a/WebBlocks/WebBlocks.SandboxV7/Views/Shared/BlockPreviewRender.cshtml
+++ b/WebBlocks/WebBlocks.SandboxV7/Views/Shared/BlockPreviewRender.cshtml
@@ -1,4 +1,4 @@
-﻿@inherits WebBlocks.ViewTemplates.WebBlocksTemplatePage
+﻿@inherits WebBlocks.ViewTemplates.WebBlocksViewPage
 	
 @{
     //this block is used to render blocks dragged in the backoffice.  Please do not edit or delete this file.


### PR DESCRIPTION
@inherits WebBlocks.ViewTemplates.WebBlocksViewPage is the correct term here, the old @inherits WebBlocks.ViewTemplates.WebBlocksTemplatePage doesnt exist in the namespace, which causes errors when dragging a block onto a page